### PR TITLE
fix: オペコード実装のクリティカルなバグを修正

### DIFF
--- a/internal/cpu/opcodes.go
+++ b/internal/cpu/opcodes.go
@@ -83,8 +83,7 @@ func (cpu *CPU) ASL(mode addressingMode) error {
 		cpu.Bus.WriteMemory(address, value)
 	}
 
-	cpu.updateZeroFlag(cpu.registerA)
-	cpu.updateNegativeFlag(value)
+	cpu.updateZeroAndNegativeFlags(value)
 
 	return nil
 }
@@ -122,11 +121,9 @@ func (cpu *CPU) BIT(mode addressingMode) error {
 
 	result := cpu.registerA & value
 
-	isOverflow := (result & byte(0b0100_0000) >> 6) == 1
-	cpu.status.setO(isOverflow)
-
-	isNegative := (result & byte(0b1000_0000) >> 7) == 1
-	cpu.status.setN(isNegative)
+	// BIT命令では、メモリ値のbit 6と7を直接プロセッサステータスにコピー
+	cpu.status.setO((value & 0b0100_0000) != 0)
+	cpu.status.setN((value & 0b1000_0000) != 0)
 
 	cpu.updateZeroFlag(result)
 
@@ -210,17 +207,11 @@ func (cpu *CPU) CMP(mode addressingMode) error {
 	address := cpu.getOperandAddress(mode)
 
 	value := cpu.Bus.ReadMemory(address)
-	if cpu.registerA == value {
-		cpu.status.setZ(true)
-	}
-	if cpu.registerA >= value {
-		cpu.status.setC(true)
-	}
-	if value&0b1000_0000 != 0 {
-		cpu.status.setN(true)
-	} else {
-		cpu.status.setN(false)
-	}
+	result := int16(cpu.registerA) - int16(value)
+	
+	cpu.status.setZ(cpu.registerA == value)
+	cpu.status.setC(cpu.registerA >= value)
+	cpu.status.setN((result & 0x80) != 0)
 
 	return nil
 }
@@ -229,17 +220,11 @@ func (cpu *CPU) CPX(mode addressingMode) error {
 	address := cpu.getOperandAddress(mode)
 
 	value := cpu.Bus.ReadMemory(address)
-	if cpu.registerX == value {
-		cpu.status.setZ(true)
-	}
-	if cpu.registerX >= value {
-		cpu.status.setC(true)
-	}
-	if value&0b1000_0000 != 0 {
-		cpu.status.setN(true)
-	} else {
-		cpu.status.setN(false)
-	}
+	result := int16(cpu.registerX) - int16(value)
+	
+	cpu.status.setZ(cpu.registerX == value)
+	cpu.status.setC(cpu.registerX >= value)
+	cpu.status.setN((result & 0x80) != 0)
 
 	return nil
 }
@@ -248,17 +233,11 @@ func (cpu *CPU) CPY(mode addressingMode) error {
 	address := cpu.getOperandAddress(mode)
 
 	value := cpu.Bus.ReadMemory(address)
-	if cpu.registerY == value {
-		cpu.status.setZ(true)
-	}
-	if cpu.registerY >= value {
-		cpu.status.setC(true)
-	}
-	if value&0b1000_0000 != 0 {
-		cpu.status.setN(true)
-	} else {
-		cpu.status.setN(false)
-	}
+	result := int16(cpu.registerY) - int16(value)
+	
+	cpu.status.setZ(cpu.registerY == value)
+	cpu.status.setC(cpu.registerY >= value)
+	cpu.status.setN((result & 0x80) != 0)
 
 	return nil
 }
@@ -494,8 +473,7 @@ func (cpu *CPU) ROR(mode addressingMode) error {
 		cpu.Bus.WriteMemory(address, value)
 	}
 
-	cpu.updateZeroFlag(cpu.registerA)
-	cpu.updateNegativeFlag(value)
+	cpu.updateZeroAndNegativeFlags(value)
 
 	return nil
 }


### PR DESCRIPTION
スネークゲームの動作不良の原因となっていたオペコード実装の以下のバグを修正:

- BIT命令: メモリ値のbit 6/7を直接プロセッサステータスにコピーするよう修正
- CMP/CPX/CPY命令: 比較結果(register - value)に基づいてNフラグを設定するよう修正
- ASL/ROR命令: フラグ更新の不整合を修正し、処理された値を使用するよう統一

----

Closes #4

Generated with [Claude Code](https://claude.ai/code)